### PR TITLE
Prevent vultr-helper.sh from crashing on older versions of BASH

### DIFF
--- a/helper-scripts/vultr-helper.sh
+++ b/helper-scripts/vultr-helper.sh
@@ -1,18 +1,25 @@
 #!/bin/bash
 
-shopt -s inherit_errexit
-
 ###################################################################
 ## Vultr Marketplace Helper Functions
+
+function inherit_errexit()
+{
+    if ! shopt -sq inherit_errexit > /dev/null 2>&1; then
+        echo "Unable to enable inherit_errexit"
+    fi
+}
 
 function error_detect_on()
 {
     set -euo pipefail
+    inherit_errexit
 }
 
 function error_detect_off()
 {
     set +euo pipefail
+    inherit_errexit
 }
 
 function enable_verbose_commands()
@@ -138,7 +145,8 @@ function set_vultr_kernel_option()
 
 function install_cloud_init()
 {
-    if [[ -x "$(command -v cloud-init >/dev/null 2>&1)" ]]; then
+    local cloudinit_exe=""
+    if cloudinit_exe="$(command -v cloud-init 2>/dev/null)" && [[ -x "${cloudinit_exe}" ]]; then
         echo "cloud-init is already installed."
         return
     fi


### PR DESCRIPTION
`inherit_errexit` was added in BASH 4.4+, which is still newer than the version included in some of the still supported operating systems. Wrapping the enablement in an `if` should allow for newer shells to benefit and older shells to carry on.